### PR TITLE
Add a link to fluentd.org in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# fluent-plugin-flowcounter-simple [![Build Status](https://secure.travis-ci.org/sonots/fluent-plugin-flowcounter-simple.png?branch=master)](http://travis-ci.org/sonots/fluent-plugin-flowcounter-simple)
+# fluent-plugin-flowcounter-simple, a plugin for [Fluentd](http://fluentd.org) [![Build Status](https://secure.travis-ci.org/sonots/fluent-plugin-flowcounter-simple.png?branch=master)](http://travis-ci.org/sonots/fluent-plugin-flowcounter-simple)
 
 Simple Fluentd Plugin to count number of messages and outputs to log
 


### PR DESCRIPTION
I am adding a link to Fluentd.org in your README.md file to put Fluentd in context for newcomers.
