### PR TITLE
test: don't use deprecated way of capturing logs

### DIFF
--- a/test/helper.rb
+++ b/test/helper.rb
@@ -1,28 +1,10 @@
-require 'rubygems'
-require 'bundler'
+require "test-unit"
+require "fluent/test"
 
-require 'test/unit'
-require 'test/unit/rr'
-
-$LOAD_PATH.unshift(File.join(File.dirname(__FILE__), '..', 'lib'))
-$LOAD_PATH.unshift(File.dirname(__FILE__))
-
-require 'fluent/test'
-
-class Test::Unit::TestCase
-  def capture_log(log)
-    if defined?(Fluent::Test::TestLogger) and log.is_a?(Fluent::Test::TestLogger) # v0.14
-      yield
-      log.out.logs.join("\n")
-    else
-      begin
-        tmp = log.out
-        log.out = StringIO.new
-        yield
-        return log.out.string
-      ensure
-        log.out = tmp
-      end
+module Helper
+  def normalize_logs(logs)
+    logs.collect do |log|
+      log.gsub(/\A\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2} [-+]\d{4} \[info\]: /, "") 
     end
   end
 end

--- a/test/plugin/test_filter_flowcounter_simple.rb
+++ b/test/plugin/test_filter_flowcounter_simple.rb
@@ -4,6 +4,7 @@ require 'fluent/plugin/filter_flowcounter_simple'
 
 class FlowCounterSimpleFilterTest < Test::Unit::TestCase
   include Fluent
+  include Helper
 
   def setup
     Fluent::Test.setup
@@ -25,9 +26,10 @@ class FlowCounterSimpleFilterTest < Test::Unit::TestCase
       msgs << {'message'=> 'b' * 100}
     end
     d = create_driver
-    filtered, out = filter(d, msgs)
+    filtered, logs = filter(d, msgs)
     assert_equal msgs, filtered
-    assert { out.include?("count:20") }
+    assert_equal(["plugin:filter_flowcounter_simple\tcount:20\tindicator:num\tunit:second\n"],
+                 normalize_logs(logs))
   end
 
   private
@@ -37,10 +39,8 @@ class FlowCounterSimpleFilterTest < Test::Unit::TestCase
       msgs.each {|msg|
         d.feed(msg)
       }
-    }
-    out = capture_log(d.instance.log) do
       d.instance.flush_emit(0)
-    end
-    [d.filtered_records, out]
+    }
+    [d.filtered_records, d.logs]
   end
 end

--- a/test/plugin/test_out_flowcounter_simple.rb
+++ b/test/plugin/test_out_flowcounter_simple.rb
@@ -3,6 +3,8 @@ require 'fluent/test/driver/output'
 require 'fluent/plugin/out_flowcounter_simple'
 
 class FlowCounterSimpleOutputTest < Test::Unit::TestCase
+  include Helper
+
   def setup
     Fluent::Test.setup
   end
@@ -38,9 +40,10 @@ class FlowCounterSimpleOutputTest < Test::Unit::TestCase
         d1.feed({'message'=> 'b' * 100})
         d1.feed({'message'=> 'c' * 100})
       end
+      d1.instance.flush_emit(60)
     end
-    out = capture_log(d1.instance.log) { d1.instance.flush_emit(60) }
-    assert { out.include?("count:30") }
+    assert_equal(["plugin:out_flowcounter_simple\tcount:30\tindicator:num\tunit:second\n"],
+                 normalize_logs(d1.logs))
   end
 
   def test_byte
@@ -51,9 +54,10 @@ class FlowCounterSimpleOutputTest < Test::Unit::TestCase
         d1.feed({'message'=> 'b' * 100})
         d1.feed({'message'=> 'c' * 100})
       end
+      d1.instance.flush_emit(60)
     end
-    out = capture_log(d1.instance.log) { d1.instance.flush_emit(60) }
-    assert { out =~ /count:\d+\tindicator:byte\tunit:second/ }
+    assert_equal(["plugin:out_flowcounter_simple\tcount:3330\tindicator:byte\tunit:second\n"],
+                 normalize_logs(d1.logs))
   end
 
   def test_comment
@@ -64,8 +68,9 @@ class FlowCounterSimpleOutputTest < Test::Unit::TestCase
         d1.feed({'message'=> 'b' * 100})
         d1.feed({'message'=> 'c' * 100})
       end
+      d1.instance.flush_emit(60)
     end
-    out = capture_log(d1.instance.log) { d1.instance.flush_emit(60) }
-    assert { out.include?("comment:foobar") }
+    assert_equal(["plugin:out_flowcounter_simple\tcount:3\tindicator:num\tunit:second\tcomment:foobar\n"],
+                 normalize_logs(d1.logs))
   end
 end


### PR DESCRIPTION
# Background

The next [td-agent](https://github.com/fluent/fluent-package-builder) will embed Ruby 3.2.

I was checking each embedded plugin and noticed that this plugin has no GitHub CI.

I added CI to my forked repository, but I found the tests are unstable on Windows and macOS.

* https://github.com/daipom/fluent-plugin-flowcounter-simple/actions/runs/4239789791

So, I created this PR first.
Following this, I would like to create a PR to add GitHub CI.

# About this fix

We should use `Driver::logs` instead of `capture_log` to fix unstable tests.

`capture_log` is defined by this plugin here.

https://github.com/fluent-plugins-nursery/fluent-plugin-flowcounter-simple/blob/5081e88f97156e019115cab2b4cd810c28ca2ed0/test/helper.rb#L12-L28

However, this is for older versions as well as the following, and this makes tests unstable.

* https://github.com/fluent/fluentd/blob/6c649d189b5cf65ccfce58f6952a31b24c775e72/lib/fluent/test/helpers.rb#L110-L122

# Reproduce failing tests

Windows seems to have the highest probability of failure.

* my forked repository's CI: https://github.com/daipom/fluent-plugin-flowcounter-simple/actions/runs/4239789791
* On my Windows10 Home machine
  * Ruby 3.2
  * Each test sometimes succeeds and sometimes does not.
  ```console
  $ bundle
  $ bundle exec rake
  C:/Ruby32-x64/bin/ruby.exe -w -I"lib;lib;test" C:/Ruby32-x64/lib/ruby/gems/3.2.0/gems/rake-13.0.6/lib/rake/rake_test_loader.rb "test/plugin/test_filter_flowcounter_simple.rb" "test/plugin/test_out_flowcounter_simple.rb"
  C:/Ruby32-x64/lib/ruby/gems/3.2.0/gems/bundler-2.3.0/lib/bundler/vendor/thor/lib/thor/error.rb:105: warning: constant DidYouMean::SPELL_CHECKERS is deprecated
  Calling `DidYouMean::SPELL_CHECKERS.merge!(error_name => spell_checker)' has been deprecated. Please call `DidYouMean.correct_error(error_name, spell_checker)' instead.
  C:/Ruby32-x64/lib/ruby/gems/3.2.0/gems/serverengine-2.3.1/lib/serverengine/socket_manager_win.rb:140: warning: assigned but unused variable - type
  C:/Ruby32-x64/lib/ruby/gems/3.2.0/gems/cool.io-1.7.1/lib/iobuffer_ext.so: warning: method redefined; discarding old initialize
  C:/Ruby32-x64/lib/ruby/gems/3.2.0/gems/cool.io-1.7.1/lib/iobuffer_ext.so: warning: method redefined; discarding old clear
  C:/Ruby32-x64/lib/ruby/gems/3.2.0/gems/cool.io-1.7.1/lib/iobuffer_ext.so: warning: method redefined; discarding old empty?
  C:/Ruby32-x64/lib/ruby/gems/3.2.0/gems/cool.io-1.7.1/lib/iobuffer_ext.so: warning: method redefined; discarding old write
  C:/Ruby32-x64/lib/ruby/gems/3.2.0/gems/fluentd-1.15.3-x64-mingw-ucrt/lib/fluent/plugin_helper.rb:46: warning: method redefined; discarding old inherited
  C:/Ruby32-x64/lib/ruby/gems/3.2.0/gems/fluentd-1.15.3-x64-mingw-ucrt/lib/fluent/plugin_helper.rb:46: warning: previous definition of inherited was here
  Loaded suite C:/Ruby32-x64/lib/ruby/gems/3.2.0/gems/rake-13.0.6/lib/rake/rake_test_loader
  Started
  F
  ==============================================================================================================================================================================================================================================
        assert { out.include?("count:20") }
                 |   |
                 |   false
                 ""
  C:/Users/reang/Documents/work/fluentd/fluentdPlugins/fluent-plugin-flowcounter-simple/test/plugin/test_filter_flowcounter_simple.rb:30:in `test_filter'
       27:     d = create_driver
       28:     filtered, out = filter(d, msgs)
       29:     assert_equal msgs, filtered
    => 30:     assert { out.include?("count:20") }
       31:   end
       32:
       33:   private
  ==============================================================================================================================================================================================================================================....
  Finished in 0.5054875 seconds.
  ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------5 tests, 9 assertions, 1 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
  ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------9.89 tests/s, 17.80 assertions/s
  Command failed with status (1): [ruby -w -I"lib;lib;test" C:/Ruby32-x64/lib/ruby/gems/3.2.0/gems/rake-13.0.6/lib/rake/rake_test_loader.rb "test/plugin/test_filter_flowcounter_simple.rb" "test/plugin/test_out_flowcounter_simple.rb" ]

  Tasks: TOP => default => test
  (See full trace by running task with --trace)
  ```