### PR TITLE
Add CI as GitHub Actions

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -1,0 +1,20 @@
+name: Test
+on: [push, pull_request]
+jobs:
+  Test:
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ 'ubuntu-latest', 'macos-latest', 'windows-latest' ]
+        ruby: [ '2.7', '3.0', '3.1', '3.2' ]
+    name: Ruby ${{ matrix.ruby }} on ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: ${{ matrix.ruby }}
+          bundler-cache: true
+      - name: Test
+        run: bundle exec rake


### PR DESCRIPTION
The next [td-agent](https://github.com/fluent/fluent-package-builder) will embed Ruby 3.2.

I was checking each embedded plugin and noticed that this plugin has no GitHub CI.

How about adding GitHub CI like this?

Note: the tests are unstable on Windows and macOS. It will be fixed by the following PR.

* #7
* Some tests are failing on my forked repository: https://github.com/daipom/fluent-plugin-flowcounter-simple/actions/runs/4239789791
* When merging #7, all tests are successful: https://github.com/daipom/fluent-plugin-flowcounter-simple/actions/runs/4240280917
